### PR TITLE
extend the demo to listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Adjust the values in `biddingBot.ts` to make an offer on a collection and an ind
 yarn bidding-bot
 ```
 
+### Make Listings
+
+Adjust the values in `listingBot.ts` to make a listing on an individual item. Then run the following command to make the listing.
+
+```sh
+yarn listing-bot
+```
+
 ### Demo Fulfillment
 
 To see how to fulfill an offer, run the following command with the order hash of the offer you want to fulfill and the address you would fulfill it from. If you're fulfilling a criteria offer, you also need to pass in the contract address and token ID of the NFT you're trying to fulfill with.

--- a/listingBot.ts
+++ b/listingBot.ts
@@ -1,0 +1,23 @@
+require("dotenv").config()
+import { buildItemListing } from "./src/buildListing"
+import { getNetwork } from "./src/network"
+import { postItemListing as postItemListing } from "./src/postListing"
+import { signOffer as signListing } from "./src/signOffer"
+
+const network = getNetwork()
+
+async function main() {
+  // Build and post an item listing (to sell)
+  const itemListing = await buildItemListing({
+    assetContractAddress: network.itemAssetContractAddress,
+    tokenId: network.itemTokenIdentifier,
+    priceWei: BigInt("110000000000000000"),
+    expirationSeconds: BigInt(901),
+  })
+  const itemSignature = await signListing(itemListing)
+  const itemResponse = await postItemListing(itemListing, itemSignature)
+  const itemOrderHash = itemResponse.order.order_hash
+  console.log(`Item listing posted! Order Hash: ${itemOrderHash}`)
+}
+
+main().catch(error => console.error(error))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "test"
   },
   "scripts": {
+    "listing-bot": "ts-node --project tsconfig.json listingBot.ts",
     "bidding-bot": "ts-node --project tsconfig.json biddingBot.ts",
     "build": "tsc -p tsconfig.build.json",
     "check-types": "tsc --noEmit",

--- a/src/buildListing.ts
+++ b/src/buildListing.ts
@@ -96,14 +96,13 @@ const getItemFees = async (
 const getItemTokenConsideration = async (
   price: bigint,
 ) => {
-  const newPrice = price / BigInt(20) * BigInt(19); // Use 'n' suffix to indicate BigInt literals
   const offerer = getOfferer()
   return {
     itemType: 0,
     token: "0x0000000000000000000000000000000000000000",
     identifierOrCriteria: 0,
-    startAmount: newPrice.toString(),
-    endAmount: newPrice.toString(),
+    startAmount: price.toString(),
+    endAmount: price.toString(),
     recipient: offerer,
   }
 }
@@ -154,10 +153,18 @@ export const buildItemListing = async (
     tokenId,
     priceWei,
   )
-  // TODO we need to update the price for the item: 
-  // subtract the fees from the initial price, as they are set as a % of the initial price
-  // TEMPORARY FIX: subtract 5% = 2.5% (SC creator fee) + 2.5% opensea, but this needs to be checked
-  console.log("... buildItemListing: We apply a temporary fix here for the consideration")
+
+  // update the price for the first fee, which is the amount the seller will receive
+  let priceStartAmount = BigInt(priceWei)
+  for (let i = 1; i < consideration.length; i++) {
+    priceStartAmount = priceStartAmount - BigInt(consideration[i].startAmount)
+  }
+  let priceEndAmount = BigInt(priceWei)
+  for (let i = 1; i < consideration.length; i++) {
+    priceEndAmount = priceEndAmount - BigInt(consideration[i].endAmount)
+  }
+  consideration[0].startAmount = priceStartAmount.toString()
+  consideration[0].endAmount = priceEndAmount.toString()
 
   const offer = {
     offerer: getOfferer(),

--- a/src/buildListing.ts
+++ b/src/buildListing.ts
@@ -1,0 +1,243 @@
+import { Chain, Fees } from "opensea-js/lib/types"
+import { apiClient, sdkClient } from "./apiClient"
+import { getNetwork } from "./network"
+import { seaportContractAddress } from "./seaport"
+import { getWallet } from "./wallet"
+
+const network = getNetwork()
+
+const conduitKey =
+  "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000"
+
+type Consideration = {
+  itemType: number
+  token: string
+  identifierOrCriteria: string | number
+  startAmount: string | number
+  endAmount: string | number
+  recipient: string
+}
+
+const getOfferer = () => {
+  const wallet = getWallet()
+  return wallet.address
+}
+
+// Create listing item for an offer
+const getOffer = (priceWei: bigint, tokenId: string) => {
+  return [
+    {
+      // itemType: 1, // ERC 20
+      itemType: 2, // the offer array must have exactly one item, and it must be an ERC721 or ERC1155 token.
+      token: network.itemAssetContractAddress, // nft contract address
+      identifierOrCriteria: tokenId,
+      // startAmount: priceWei.toString(),
+      // endAmount: priceWei.toString(),
+      startAmount: '1',
+      endAmount: '1',
+    },
+  ]
+}
+
+// Fee item for an offer
+const getFee = (
+  priceWei: bigint,
+  feeBasisPoints: bigint,
+  recipient: string,
+): Consideration | null => {
+  const fee = (priceWei * feeBasisPoints) / BigInt(10000)
+  if (fee <= 0) {
+    return null
+  }
+  return {
+    itemType: 0, 
+    token: "0x0000000000000000000000000000000000000000",
+    identifierOrCriteria: 0,
+    startAmount: fee.toString(),
+    endAmount: fee.toString(),
+    recipient: recipient,
+  }
+}
+
+// Extract fees from an API response
+const extractFeesApi = (feesObject: object, priceWei: bigint) => {
+  const fees = []
+
+  for (const [_category, categoryFees] of Object.entries(feesObject)) {
+    for (const [address, basisPoints] of Object.entries(categoryFees)) {
+      const fee = getFee(priceWei, BigInt(basisPoints as number), address)
+      if (fee) {
+        fees.push(fee)
+      }
+    }
+  }
+
+  return fees
+}
+
+// Extract fees from an SDK response
+const extractFeesSdk = (feesObject: Fees, priceWei: bigint) => {
+  const fees = []
+  const feesToAdd = [...feesObject.openseaFees, ...feesObject.sellerFees]
+
+  for (const [address, basisPoints] of feesToAdd) {
+    const fee = getFee(priceWei, BigInt(basisPoints), address)
+    if (fee) {
+      fees.push(fee)
+    }
+  }
+
+  return fees
+}
+
+// Get item fees / considerations, from OpenSea's SDK
+const getItemFees = async (
+  assetContractAddress: string,
+  tokenId: string,
+  priceWei: bigint,
+) => {
+  const response = await sdkClient.api.getNFT(
+    network.network,
+    assetContractAddress,
+    tokenId,
+  )
+
+  const collectionSlug = response.nft.collection
+  const collection = await sdkClient.api.getCollection(collectionSlug)
+  const fees = collection.fees
+  const feesUpdated = extractFeesSdk(fees, priceWei)
+  return feesUpdated
+}
+
+// Get criteria fees from an API
+const getCriteriaFees = async (collectionSlug: string, priceWei: bigint) => {
+  const response = await apiClient.get(`v1/collection/${collectionSlug}`)
+
+  const feesObject = response.data.collection.fees
+  return extractFeesApi(feesObject, priceWei)
+}
+
+// Get build data for an offer
+const getBuildData = async (collectionSlug: string, quantity: number) => {
+  const offerer = getOfferer()
+  const response = await apiClient.post("v2/offers/build", {
+    offerer,
+    quantity,
+    criteria: {
+      collection: {
+        slug: collectionSlug,
+      },
+    },
+    protocol_address: seaportContractAddress,
+  })
+
+  return response.data.partialParameters
+}
+
+// Get consideration for an item token
+const getItemTokenConsideration = async (
+  assetContractAddress: string,
+  tokenId: string,
+  price: bigint,
+) => {
+  const newPrice = price / BigInt(20) * BigInt(19); // Use 'n' suffix to indicate BigInt literals
+  // const newprice = price /20*19
+  const offerer = getOfferer()
+  return {
+    itemType: 0,
+    token: "0x0000000000000000000000000000000000000000",
+    identifierOrCriteria: 0,
+    startAmount: newPrice.toString(),
+    endAmount: newPrice.toString(),
+    recipient: offerer,
+  }
+}
+
+const getCriteriaConsideration = async (
+  criteriaFees: unknown[],
+  collectionSlug: string,
+  priceWei: bigint,
+) => {
+  const fees = [
+    ...criteriaFees,
+    ...(await getCriteriaFees(collectionSlug, priceWei)),
+  ]
+
+  return fees.filter(fee => fee !== null)
+}
+
+const getItemConsideration = async (
+  assetContractAddress: string,
+  tokenId: string,
+  priceWei: bigint,
+) => {
+  const fees = [
+    await getItemTokenConsideration(assetContractAddress, tokenId, priceWei),
+    ...(await getItemFees(assetContractAddress, tokenId, priceWei)),
+  ]
+
+  return fees
+}
+
+// Generate a random salt value
+const getSalt = () => {
+  return Math.floor(Math.random() * 100_000).toString()
+}
+
+// Define the structure for a collection offer specification
+type CollectionOfferSpecification = {
+  collectionSlug: string
+  quantity: number
+  priceWei: bigint
+  expirationSeconds: bigint
+}
+
+// Define the structure for an item offer specification
+type ItemOfferSpecification = {
+  assetContractAddress: string
+  tokenId: string
+  priceWei: bigint
+  expirationSeconds: bigint
+}
+
+export const buildItemListing = async (
+  offerSpecification: ItemOfferSpecification,
+) => {
+  const {
+    assetContractAddress,
+    tokenId,
+    priceWei,
+    expirationSeconds,
+  } = offerSpecification
+
+  const now = BigInt(Math.floor(Date.now() / 1000))
+  const startTime = now.toString()
+  const endTime = (now + expirationSeconds).toString()
+  const consideration = await getItemConsideration(
+    assetContractAddress,
+    tokenId,
+    priceWei,
+  )
+  // TODO we need to update the price for the item: 
+  // subtract the fees from the initial price, as they are set as a % of the initial price
+  // TEMPORARY FIX: subtract 5% = 2.5% (SC creator fee) + 2.5% opensea, but this needs to be checked
+  console.log("... buildItemListing: We apply a temporary fix here for the consideration")
+
+  const offer = {
+    offerer: getOfferer(),
+    offer: getOffer(priceWei,tokenId),
+    consideration,
+    startTime,
+    endTime,
+    orderType: 0,
+    zone: "0x0000000000000000000000000000000000000000",
+    zoneHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    salt: getSalt(),
+    conduitKey,
+    totalOriginalConsiderationItems: consideration.length.toString(),
+    counter: 0,
+  }
+
+  return offer
+}

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,9 +1,12 @@
 import { Chain } from "opensea-js"
 
-const getEnvRequired = (key: string) => {
+// Define a function to retrieve a required environment variable
+const getEnvRequired = (key: string, defaultValue: string = '') => {
   const value = process.env[key]
   if (value === undefined) {
-    throw new Error(`Missing required environment variable: ${key}`)
+    // throw new Error(`Missing required environment variable: ${key}`)
+    console.warn(`Missing environment variable: ${key}. Continuing with default value.`)
+    return defaultValue
   }
   return value
 }
@@ -22,6 +25,20 @@ const networks = {
       "MAINNET_ITEM_ASSET_CONTRACT_ADDRESS",
     ),
     itemTokenIdentifier: getEnvRequired("MAINNET_ITEM_TOKEN_IDENTIFIER"),
+  },
+  polygon: {
+    chainId: 137,
+    chainName: "polygon", 
+    baseURL: "https://api.opensea.io/api/",
+    wethAddress: "???",
+    apiKey: getEnvRequired("API_KEY"),
+    rpcUrl: getEnvRequired("POLYGON_RPC_URL"),
+    network: Chain.Polygon,
+    collectionSlug: getEnvRequired("POLYGON_COLLECTION_SLUG"),
+    itemAssetContractAddress: getEnvRequired(
+      "POLYGON_ITEM_ASSET_CONTRACT_ADDRESS",
+    ),
+    itemTokenIdentifier: getEnvRequired("POLYGON_ITEM_TOKEN_IDENTIFIER"),
   },
   testnets: {
     chainId: 5,
@@ -42,11 +59,14 @@ const networks = {
   },
 }
 
+// Get the network configuration based on the environment variable
 export const getNetwork = () => {
   const network = process.env.NETWORK
   switch (network) {
     case "mainnet":
       return networks.mainnet
+    case "polygon":
+      return networks.polygon
     case "testnets":
       return networks.testnets
     case undefined:

--- a/src/postListing.ts
+++ b/src/postListing.ts
@@ -1,0 +1,23 @@
+import { apiClient } from "./apiClient"
+import { getNetwork } from "./network"
+import { seaportContractAddress } from "./seaport"
+
+const network = getNetwork()
+
+export const postItemListing = async (offer: unknown, signature: string) => {
+  const payload = {
+    parameters: offer,
+    signature,
+    protocol_address: seaportContractAddress,
+  }
+  return await apiClient
+    .post(`v2/orders/${network.network}/seaport/listings`, payload)
+    .then(response => {
+      return response.data
+    })
+    .catch(function (error) {
+      console.log("... postitemListing: error: ")
+      console.error(error.response.data)
+      console.log(error.response)
+    })
+}


### PR DESCRIPTION
The code is extended by the file listingBot (and related files). 

By using 'yarn listing-bot' the item described in .env is being listed. Necessary example parameters:

'POLYGON_COLLECTION_SLUG='mySlugName'  '
POLYGON_ITEM_ASSET_CONTRACT_ADDRESS='myItemAssetContractAddress'
POLYGON_ITEM_TOKEN_IDENTIFIER='myTokenIdentifier'

---------
The code has been tested on the polygon network.